### PR TITLE
State clearly not to open a new issue to enrol

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To officially register for this course you must create a profile in our [student
 
 > **"How can I do this?"**
 
-Comment in [this](https://github.com/open-source-society/computer-science-and-engineering/issues/31) issue using the following template:
+Comment in [this](https://github.com/open-source-society/computer-science-and-engineering/issues/31) issue  (please, do **not** open a new one) using the following template:
 
 ```
 - **Name**: YOUR NAME


### PR DESCRIPTION
Just a suggestion, you may want to rephrase it as you like. 
The goal is to make it clearer to comment on the existing issue rather than opening a new one that creates noise and will eventually be closed anyway.

Cheers!